### PR TITLE
Two part reg

### DIFF
--- a/android/src/main/java/org/aerogear/unifiedpush/android/RnUnifiedPushModule.java
+++ b/android/src/main/java/org/aerogear/unifiedpush/android/RnUnifiedPushModule.java
@@ -1,6 +1,7 @@
 package org.aerogear.unifiedpush.android;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -10,73 +11,171 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 
 import org.jboss.aerogear.android.unifiedpush.MessageHandler;
 import org.jboss.aerogear.android.unifiedpush.PushRegistrar;
 import org.jboss.aerogear.android.unifiedpush.RegistrarManager;
 import org.jboss.aerogear.android.unifiedpush.fcm.AeroGearFCMPushConfiguration;
+import org.jboss.aerogear.android.unifiedpush.fcm.AeroGearFCMPushRegistrar;
 
 import java.net.URI;
+import java.util.ArrayList;
 
 public class RnUnifiedPushModule extends ReactContextBaseJavaModule {
 
+    public static final String MODULE_NAME = "RnUnifiedPush";
     private final ReactApplicationContext reactContext;
+
+    private static final String REACT_NATIVE_PUSH_REGISTRAR_KEY = "org.jboss.aerogear.android.unifiedpush.REGISTRAR";
+    private final SharedPreferences prefs;
 
     public RnUnifiedPushModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
+
+        //In theory react native modules may not stay in memory between providing the init config
+        //which won't change between app boots and register
+        //We use prefs to save the init config if this happens and register is called
+        //after init has been called before a GC.
+        this.prefs = reactContext.getSharedPreferences(MODULE_NAME, Context.MODE_PRIVATE);
     }
 
     @Override
     public String getName() {
-        return "RnUnifiedPush";
+        return MODULE_NAME;
     }
 
     @ReactMethod
     public void initialize(
             ReadableMap config, final Promise promise) {
-  
-      Log.i("REG", "INIT CALLED")          ;
 
-      ReadableMap androidConfig = config.getMap("android");
+        try {
+            ReadableMap androidConfig = config.getMap("android");
+            String uri = config.getString("pushServerURL");
+            String senderID = androidConfig.getString("senderID");
+            String variantID = androidConfig.getString("variantID");
+            String secret = androidConfig.getString("variantSecret");
 
-      RegistrarManager.config("register", AeroGearFCMPushConfiguration.class)
-          .setPushServerURI(URI.create(config.getString("pushServerURL")))
-          .setSenderId(androidConfig.getString("senderID"))
-          .setVariantID(androidConfig.getString("variantID"))
-          .setSecret(androidConfig.getString("variantSecret"))
-          .asRegistrar();
-  
-      PushRegistrar registrar = RegistrarManager.getRegistrar("register");
-      registrar.register(
-          getCurrentActivity().getApplicationContext(),
-          new org.jboss.aerogear.android.core.Callback<Void>() {
-            @Override
-            public void onSuccess(Void data) {
-              new Handler(Looper.getMainLooper())
-                  .post(
-                      new Runnable() {
-                        @Override
-                        public void run() {
-                          promise.resolve(null);
-                        }
-                      });
+            //if the uri is invalid we'll catch the exception
+            URI.create(uri);
+
+
+            if (verifyInitialize(uri, senderID, variantID, secret, promise)) {
+                prefs.edit()
+                        .putString("pushServerURL", uri)
+                        .putString("senderID", senderID)
+                        .putString("variantID", variantID)
+                        .putString("variantSecret", secret)
+                        .commit();
+                promise.resolve(true);
             }
-  
-            @Override
-            public void onFailure(final Exception exception) {
-              new Handler(Looper.getMainLooper())
-                  .post(
-                      new Runnable() {
-                        @Override
-                        public void run() {
-                          Log.e("REGISTRATION", exception.getMessage(), exception);
-                          promise.reject(exception);
-                        }
-                      });
+        } catch (Exception exception) {
+            promise.reject(MODULE_NAME, exception);
+        }
+    }
+
+    private boolean verifyInitialize(String uri, String senderID, String variantID, String secret, Promise promise) {
+        if (uri == null) {
+            promise.reject(MODULE_NAME, "pushServerURL must not be null");
+            return false;
+        }
+        if (senderID == null) {
+            promise.reject(MODULE_NAME, "senderID must not be null");
+            return false;
+        }
+        if (variantID == null) {
+            promise.reject(MODULE_NAME, "variantID must not be null");
+            return false;
+        }
+        if (secret == null) {
+            promise.reject(MODULE_NAME, "variantSecret must not be null");
+            return false;
+        }
+        return true;
+    }
+
+    @ReactMethod
+    public void register(
+            ReadableMap config, final Promise promise) {
+        try {
+            if (!verifyPrefs()) {
+                promise.reject(MODULE_NAME, "Please call initialize before you register.");
             }
-          });
+
+            URI uri = URI.create(prefs.getString("pushServerURL", ""));
+            String secret = prefs.getString("variantSecret", "");
+            String variantID = prefs.getString("variantID", "");
+            String senderID = prefs.getString("senderID", "");
+
+
+            AeroGearFCMPushConfiguration pushConfig = RegistrarManager.config(REACT_NATIVE_PUSH_REGISTRAR_KEY, AeroGearFCMPushConfiguration.class)
+                    .setPushServerURI(uri)
+                    .setSenderId(senderID)
+                    .setVariantID(variantID)
+                    .setSecret(secret);
+
+            if (config.hasKey("alias")) {
+                pushConfig.setAlias(config.getString("alias"));
+            }
+
+            if (config.hasKey("deviceType")) {
+                pushConfig.setDeviceType(config.getString("deviceType"));
+            }
+
+            if (config.hasKey("operatingSystem")) {
+                pushConfig.setOperatingSystem(config.getString("operatingSystem"));
+            }
+
+            if (config.hasKey("categories")) {
+                ReadableArray reactCategoriesArray = config.getArray("categories");
+                ArrayList<String> categoriesList = new ArrayList<>();
+                for (int i = 0; i < reactCategoriesArray.size(); i++) {
+                    categoriesList.add(reactCategoriesArray.getString(i));
+                }
+                pushConfig.setCategories(categoriesList.toArray(new String[]{}));
+            }
+
+            PushRegistrar registrar = pushConfig.asRegistrar();
+
+
+            registrar.register(
+                    getCurrentActivity().getApplicationContext(),
+                    new org.jboss.aerogear.android.core.Callback<Void>() {
+                        @Override
+                        public void onSuccess(Void data) {
+                            new Handler(Looper.getMainLooper())
+                                    .post(
+                                            new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    promise.resolve(null);
+                                                }
+                                            });
+                        }
+
+                        @Override
+                        public void onFailure(final Exception exception) {
+                            new Handler(Looper.getMainLooper())
+                                    .post(
+                                            new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    Log.e("REGISTRATION", exception.getMessage(), exception);
+                                                    promise.reject(exception);
+                                                }
+                                            });
+                        }
+                    });
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
+    }
+
+    private boolean verifyPrefs() {
+
+        return prefs.contains("pushServerURL") && prefs.contains("variantSecret") && prefs.contains("variantID") && prefs.contains("senderID");
     }
 
 }

--- a/ios/RNUnifiedPushEmitter.h
+++ b/ios/RNUnifiedPushEmitter.h
@@ -1,11 +1,3 @@
-//
-//  RNUnifiedPushEmitter.h
-//  RnUnifiedPush
-//
-//  Created by Massimiliano Ziccardi on 01/05/2020.
-//  Copyright © 2020 Facebook. All rights reserved.
-//
-
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 

--- a/ios/RNUnifiedPushEmitter.m
+++ b/ios/RNUnifiedPushEmitter.m
@@ -1,11 +1,3 @@
-//
-//  RNUnifiedPushEmitter.m
-//  RnUnifiedPush
-//
-//  Created by Massimiliano Ziccardi on 01/05/2020.
-//  Copyright © 2020 Facebook. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
 

--- a/ios/RnUnifiedPush.m
+++ b/ios/RnUnifiedPush.m
@@ -8,62 +8,152 @@ static NSDictionary* _config;
 static RCTPromiseResolveBlock _resolve;
 static RCTPromiseRejectBlock _reject;
 static RCTResponseSenderBlock _messageHandler;
+static NSUserDefaults * _preferences;
+
 
 @implementation RnUnifiedPush
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(initialize: (NSDictionary*)config 
-                 resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-  _config = config;
-  if (_deviceToken != nil) {
-      [RnUnifiedPush registerToUPS :resolve rejecter:reject];
-  } else {
-    _resolve = resolve;
-    _reject = reject;
-  }
+RCT_EXPORT_METHOD(register: (NSDictionary*)config 
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    @try {
+        [RnUnifiedPush registerToUPS :config resolver:resolve rejecter:reject];
+    }@catch(NSException *e) {
+        reject( @"RN-IOS", [NSString stringWithFormat:@" error in register2%@", e.reason], nil);
+    }
 }
 
-+ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-  _deviceToken = deviceToken;
-    RCTLogInfo(@"getting token %@", deviceToken);
-  if (_resolve != nil) {
-    [RnUnifiedPush registerToUPS :_resolve rejecter:_reject];
+RCT_EXPORT_METHOD(initialize: (NSDictionary*)config 
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    @try{
+        _preferences = [NSUserDefaults standardUserDefaults];
+        _config = config;
+        if (_deviceToken != nil) {
+            [RnUnifiedPush saveParams :resolve rejecter:reject];
+        } else {
+            _resolve = resolve;
+            _reject = reject;
+        }
+    }@catch(NSException *e) {
+        reject( @"RN-IOS", @"init error", nil);
+    }
+}
 
-  }
+
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    @try{
+        _deviceToken = deviceToken;
+        RCTLogInfo(@"getting token %@", deviceToken);
+        if (_resolve != nil) {
+            [RnUnifiedPush saveParams :_resolve rejecter:_reject];
+        }
+    }@catch(NSException *e) {
+        RCTLogInfo(@"Sending push to didRegisterForRemoteNotificationsWithDeviceToken %@", e.reason);
+        
+        _reject( @"RN-IOS", @"didRegisterForRemoteNotificationsWithDeviceToken error", nil);
+    }
 }
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)userInfo {
-  RCTLogInfo(@"Sending push to Emitter %@", userInfo);
-  [RNUnifiedPushEmitter emitEvent:userInfo];
+    RCTLogInfo(@"Sending push to Emitter %@", userInfo);
+    [RNUnifiedPushEmitter emitEvent:userInfo];
 }
 
-+ (void)registerToUPS: (RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject {
-  AGDeviceRegistration *d = [[AGDeviceRegistration alloc] initWithServerURL:[NSURL URLWithString:_config[@"pushServerURL"]]];
-  [d registerWithClientInfo:^(id<AGClientDeviceInformation> clientInfo) {
-    NSDictionary* iosConfig = [_config objectForKey:@"ios"];
-    if (iosConfig == nil) {
-      iosConfig = [_config objectForKey:@"ios_token"];
-    }
-    [clientInfo setDeviceToken:_deviceToken];
-    [clientInfo setVariantID:iosConfig[@"variantID"]];
-    [clientInfo setVariantSecret:iosConfig[@"variantSecret"]];
 
-    UIDevice *currentDevice = [UIDevice currentDevice];
-    // set some 'useful' hardware information params
-    [clientInfo setOperatingSystem:[currentDevice systemName]];
-    [clientInfo setOsVersion:[currentDevice systemVersion]];
-    [clientInfo setDeviceType:[currentDevice model]];
-  } success:^{
-      NSLog(@"RN-IOS => UnifiedPush Server registration worked");
-      NSLog(@"RN-IOS => Invoking callback");
-      resolve(@[[NSNull null]]);
-      NSLog(@"RN-IOS => Callback invoked");
-  } failure:^(NSError * err) {
-    reject( @"no_events", @"Error registering",err);
-  }];
++ (void)saveParams: (RCTPromiseResolveBlock)resolve
+          rejecter:(RCTPromiseRejectBlock)reject {
+    @try{
+        NSDictionary* iosConfig = [_config objectForKey:@"ios"];
+        
+        if (iosConfig == nil) {
+            iosConfig = [_config objectForKey:@"ios_token"];
+        }
+        
+        if (iosConfig == nil) {
+            reject( @"RN-IOS", @"iosConfig was nil", nil);
+            return;
+        }
+        
+        if ([_config objectForKey:@"pushServerURL"] == nil) {
+            reject( @"RN-IOS", @"pushServerURL was nil", nil);
+            return;
+        }
+        
+        if ([iosConfig objectForKey:@"variantID"] == nil) {
+            reject( @"RN-IOS", @"variantID was nil", nil);
+            return;
+        }
+        if ([iosConfig objectForKey:@"variantSecret"] == nil) {
+            reject( @"RN-IOS", @"variantSecret was nil", nil);
+            return;
+        }
+        
+        [_preferences setObject:_config[@"pushServerURL"] forKey:@"pushServerURL"];
+        [_preferences setObject:iosConfig[@"variantID"] forKey:@"variantID"];
+        [_preferences setObject:iosConfig[@"variantSecret"] forKey:@"variantSecret"];
+        [_preferences synchronize];
+        
+        resolve(@[[NSNull null]]);
+    }@catch(NSException *e) {
+        RCTLogInfo(@"Sending push to didReceiveRemoteNotification %@", e.reason);
+        reject( @"RN-IOS", @"didReceiveRemoteNotification error", nil);
+    }
+    
+}
+
+
++ (void)registerToUPS: (NSDictionary*)config 
+             resolver:(RCTPromiseResolveBlock)resolve
+             rejecter:(RCTPromiseRejectBlock)reject {
+    @try{
+        if ([_preferences objectForKey:@"pushServerURL"] == nil)
+        {
+            reject( @"RN-IOS", @"pushServerURL was nil, have you called initialize?", nil);
+            return;
+        }
+        
+        NSString *url =  (NSString*)[_preferences objectForKey:@"pushServerURL"];
+        NSString *variantID =  (NSString*)[_preferences objectForKey:@"variantID"];
+        NSString *variantSecret =  (NSString*)[_preferences objectForKey:@"variantSecret"];
+        
+        AGDeviceRegistration *d = [[AGDeviceRegistration alloc] initWithServerURL:[NSURL URLWithString:url]];
+        
+        [d registerWithClientInfo:^(id<AGClientDeviceInformation> clientInfo) {
+            
+            [clientInfo setDeviceToken:_deviceToken];
+            [clientInfo setVariantID:variantID];
+            [clientInfo setVariantSecret:variantSecret];
+            
+            UIDevice *currentDevice = [UIDevice currentDevice];
+            // set some 'useful' hardware information params
+            [clientInfo setOperatingSystem:[currentDevice systemName]];
+            [clientInfo setOsVersion:[currentDevice systemVersion]];
+            [clientInfo setDeviceType:[currentDevice model]];
+            
+            if ([config objectForKey:@"alias"] != nil) {
+                [clientInfo setAlias:(NSString*)[config objectForKey:@"alias"]];
+            }
+            if ([config objectForKey:@"categories"] != nil) {
+                NSArray *categories = [config objectForKey:@"categories"];
+                [clientInfo setCategories:categories];
+            }
+            
+        } success:^{
+            NSLog(@"RN-IOS => UnifiedPush Server registration worked");
+            NSLog(@"RN-IOS => Invoking callback");
+            resolve(@[[NSNull null]]);
+            NSLog(@"RN-IOS => Callback invoked");
+        } failure:^(NSError * err) {
+            reject( @"no_events", @"Error registering",err);
+        }];
+    }@catch(NSException *e) {
+        RCTLogInfo(@"registerToUPS %@", e.reason);
+        reject( @"RN-IOS", @"registerToUPS error", nil);
+    }
 }
 
 @end
+

--- a/ios/UPSEnabledAppDelegate.h
+++ b/ios/UPSEnabledAppDelegate.h
@@ -1,0 +1,13 @@
+#import <React/RCTBridgeDelegate.h>
+#import <UIKit/UIKit.h>
+
+#ifndef UPSEnabledAppDelegate_h
+#define UPSEnabledAppDelegate_h
+
+@interface UPSEnabledAppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end
+
+#endif /* UPSEnabledAppDelegate_h */

--- a/ios/UPSEnabledAppDelegate.m
+++ b/ios/UPSEnabledAppDelegate.m
@@ -1,0 +1,33 @@
+#import "UPSEnabledAppDelegate.h"
+#import <UserNotifications/UserNotifications.h>
+#import <RnUnifiedPush/RnUnifiedPush.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@implementation UPSEnabledAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  // Enable Push Notifications
+  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+  [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionBadge + UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+    
+  }];
+  [[UIApplication sharedApplication] registerForRemoteNotifications];
+  
+  return YES;
+}
+
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+  [RnUnifiedPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  NSLog(@"Received push %@",userInfo);
+  [RnUnifiedPush didReceiveRemoteNotification:userInfo];
+}
+
+@end

--- a/lib/RNUnifiedPush.js
+++ b/lib/RNUnifiedPush.js
@@ -24,6 +24,10 @@ export class RNUnifiedPush {
     return NativeRnUnifiedPush.initialize(config);
   }
 
+  register(config) {
+    return NativeRnUnifiedPush.register(config);
+  }
+
   registerMessageHandler(messageHandler) {
     this.messageHandler = messageHandler;
   }


### PR DESCRIPTION
## Motivation
This adds registering as a part separate from initialization.

## What
Android and iOS modules were refactored such that the javascript "init" method setups up the Push library, and "register" will cause a push registration.  Previously this was combined into a single step under the init method.

## Why
The init object and a registration object are separate objects, and the operations under the hood are separate as well. This had only been a single action out of historical curiosity.

## Verification Steps
Use the "rn" branch of unifiedpush-cookbook. You will also need to setup a FCM and APNS account and configure UPS accordingly. You will also need to setup the ios and Android applications for your own services or reach out to us and test ours.

1. Send a push
2. Confirm push messages are received on andriod and iOS
