### PR TITLE
build: fixed commit lint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-angular'],
+  extends: ['@commitlint/config-conventional'],
 };


### PR DESCRIPTION
## Motivation
The chore comments were not recognized
Starting from version 5.0.0 config-angular has diverged from conventional commit, so config-conventional must be used now instead of config-angular (see https://www.npmjs.com/package/@commitlint/config-conventional)